### PR TITLE
Remove eth0 from network-manager managed interfaces

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -26,7 +26,7 @@ systemctl stop syslog.socket rsyslog.service
 find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
-rm -rf ${SNAP_DATA}/userdata/etc/devicedb
+rm -rf ${SNAP_DATA}/userdata/etc
 rm -rf ${SNAP_DATA}/wigwag/etc/devicejs/devicedb.yaml
 snap stop pelion-edge.kubelet || true
 rm -rf ${SNAP_COMMON}/var/lib/kubelet
@@ -34,4 +34,3 @@ rm -rf ${SNAP_COMMON}/var/lib/kubelet
 # Stop and remove all existing docker containers and images
 docker stop $(docker ps -a -q) || true
 docker system prune --volumes -a -f || true
-

--- a/files/maestro/launch-maestro.sh
+++ b/files/maestro/launch-maestro.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 if [ ! -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json ]; then
     echo "identity.json does not exist"
@@ -14,6 +15,25 @@ fi
 
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
+fi
+
+config_file=$SNAP_DATA/maestro-config.yaml
+
+networking_disabled=$($SNAP/bin/yq r $config_file network.disable)
+
+if [ "$networking_disabled" != "true" ]; then
+
+	# Obtain interfaces maestro is managing
+	interfaces=$($SNAP/bin/yq r $config_file network.interfaces.*.if_name)
+
+	# If interfaces found, turn of nmcli management of said interfaces
+	[ $? = 0 ] && for i in $interfaces; do
+	    $SNAP/bin/nmcli dev set $i managed no
+	done
+
+	# @todo: turn on management of previous interfaces that were disabled
+	#        and are no longer managed by maestro
+
 fi
 
 exec ${SNAP}/wigwag/system/bin/maestro -config $SNAP_DATA/maestro-config.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -498,7 +498,7 @@ parts:
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git
-      source-commit: 64520703aa26861cf0415261aded3d9c2059900e
+      source-commit: a2069b14dd636af3ca7069dcb3bbd18a6fa37db9
       build-packages:
         - python
         - build-essential
@@ -513,7 +513,7 @@ parts:
         cd go/src/github.com/armPelionEdge
         git clone https://github.com/armPelionEdge/maestro.git
         cd maestro
-        git checkout 64520703aa26861cf0415261aded3d9c2059900e
+        git checkout a2069b14dd636af3ca7069dcb3bbd18a6fa37db9
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_BUILD}/go
         # Specify GOBIN so that maestro/build.sh doesn't do unexpected things

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,7 +105,7 @@ apps:
         restart-delay: 5s
       restart-condition: always
       daemon: simple
-      plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, mount-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, x11, system-files-logs]
+      plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, mount-observe, netlink-audit, netlink-connector, network-manager, network, network-bind, network-control, network-observe, x11, system-files-logs]
     maestro-shell:
       command: wigwag/system/bin/maestro-shell
       environment:
@@ -491,6 +491,10 @@ parts:
         # copied into the prime directory during the prime step
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
         install ${GOPATH}/bin/maestro-shell ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/maestro-shell
+    yq:
+      plugin: go
+      source: git@github.com:mikefarah/yq.git
+      go-importpath: github.com/mikefarah/yq
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -337,7 +337,7 @@ parts:
         - python
         - build-essential
       source: https://github.com/armPelionEdge/edge-utils.git
-      source-commit: 7020d6bd0d3a486299d33e20be3f11b61372ebeb
+      source-commit: 9abc56414972bfd3b13afb1d6e294218938c0614
       override-pull: |
         snapcraftctl pull
         cp ${SNAPCRAFT_PROJECT_DIR}/files/wwrelay-utils/package.json .


### PR DESCRIPTION
Prevents dead-lock from network-manager and maestro both trying to set a DHCP
controlled interface on eth0