### PR TITLE
kubelet: set node-status-update-frequency=150s

### DIFF
--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -35,5 +35,6 @@ exec ${SNAP}/wigwag/system/bin/kubelet \
     --cni-bin-dir=${SNAP}/wigwag/system/opt/cni/bin \
     --cni-conf-dir=${SNAP}/wigwag/system/etc/cni/net.d \
     --network-plugin=cni \
+    --node-status-update-frequency=150s \
     --register-node=true \
     $NODE_IP_OPTION


### PR DESCRIPTION
The kubelet node-status-update-frequency is described by the
kubernetes docs as:

    Specifies how often kubelet posts node status to master. Note: be
    cautious when changing the constant, it must work with
    nodeMonitorGracePeriod in nodecontroller. (default 10s)

The reason for the increase is customer demand to reduce kubernetes
related network traffic. A corresponding change will be made to the
kube-controller-manager service in the cloud to reduce its
node-monitor-grace-period.  The value of 150s was chosen because
it is the same ratio (1/4) of the value of the cloud's
node-monitor-grace-period which is being set to 600s because it is
the same value the customer chose for mbed-client lifetime.