### PR TITLE
Allow edge-proxy to connect through http-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,16 @@ Log files are captured by snap and are available with the following commands:
    journalctl -u snap.pelion-edge.edge-core -f
    ```
 
+## Proxying HTTP traffic
+When a pelion-edge device is installed in a site that restricts HTTP traffic it can be configured to pass its traffic through an HTTP proxy. The HTTP proxy can be set in the snap environment variable edge-proxy.extern-http-proxy in the following manner
+
+   ```bash
+   snap set pelion-edge edge-proxy.extern-http-proxy=<http-proxy-uri>
+   ```
+For example
+   ```bash
+   snap set pelion-edge edge-proxy.extern-http-proxy=https://webproxy.myorg.com:8443
+   ```
 ## Runtime Configuration
 
 1. The maestro service may be configured with [maestro-shell](https://github.com/armpelionedge/maestro-shell) and with [devicedb](https://github.com/armpelionedge/devicedb).  See the README of each project for more information.

--- a/files/edge-proxy/patches/0001-Correctly-handle-empty-string-for-proxy-URI.patch
+++ b/files/edge-proxy/patches/0001-Correctly-handle-empty-string-for-proxy-URI.patch
@@ -1,0 +1,42 @@
+From ae91c8c684c112a98193d9e5506e845c6a3386af Mon Sep 17 00:00:00 2001
+From: Kyle Stein <kyle.stein@arm.com>
+Date: Tue, 21 Jul 2020 14:52:21 -0500
+Subject: [PATCH] Correctly handle empty string for proxy URI
+
+Signed-off-by: Kyle Stein <kyle.stein@arm.com>
+---
+ cmd/edge-proxy/main.go | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/cmd/edge-proxy/main.go b/cmd/edge-proxy/main.go
+index 6523516..e18e0fa 100644
+--- a/cmd/edge-proxy/main.go
++++ b/cmd/edge-proxy/main.go
+@@ -167,16 +167,17 @@ func main() {
+ 				fmt.Printf("Starting edge HTTP proxy (proxyAddr=%s, proxyURI=%s)\n", proxyAddr, proxyURI)
+ 
+ 				proxyForEdge := func(req *http.Request) (*url.URL, error) {
+-					var proxy *url.URL
+ 
+-					proxy, err := url.Parse(externalHTTPProxyURI)
+-					if err != nil {
+-						return nil, nil
+-					} else {
+-						return proxy, nil
++					if externalHTTPProxyURI != "" {
++						var proxy *url.URL
++						proxy, err := url.Parse(externalHTTPProxyURI)
++						if err == nil {
++							return proxy, nil
++						}
+ 					}
+-				}
+ 
++					return nil, nil
++				}
+ 
+ 				server.RunEdgeHTTPProxyServer(childCtx, proxyAddr, forwardingAddresses(proxyURIParsed, forwardingAddressesMapParsed), caList, cert, proxyForEdge)
+ 
+-- 
+2.14.3
+

--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -21,11 +21,17 @@ EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_i
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 DEVICE_ID=$(jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/edge-proxy.conf.json)
+EXTERN_HTTP_PROXY=$(snapctl get edge-proxy.extern-http-proxy)
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
 fi
 if ! grep -q "$DEVICE_ID" /etc/hosts; then
     echo "127.0.0.1 $DEVICE_ID" >> /etc/hosts
+fi
+if [[ $EXTERN_HTTP_PROXY = "" ]]; then
+    EXTERN_ARG=
+else
+    EXTERN_ARG=-extern-http-proxy-uri=$EXTERN_HTTP_PROXY
 fi
 if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
     echo "edge-proxy logging is disabled.  To see logs, run \"snap set pelion-edge edge-proxy.debug=true\" and restart edge-proxy"
@@ -33,6 +39,8 @@ if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
     # see https://www.tldp.org/LDP/abs/html/x17974.html
     exec >/dev/null 2>&1
 fi
+
+
 
 exec ${SNAP}/wigwag/system/bin/edge-proxy \
     -proxy-uri=${EDGE_K8S_ADDRESS} \
@@ -42,4 +50,5 @@ exec ${SNAP}/wigwag/system/bin/edge-proxy \
     -cert-strategy-options=path=/1/pt \
     -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
     -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
+    $EXTERN_ARG \
     -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -21,3 +21,6 @@
 if [[ -z $(snapctl get edge-proxy.debug) ]]; then
     snapctl set edge-proxy.debug=false
 fi
+if [[ -z $(snapctl get edge-proxy.extern-http-proxy) ]]; then
+    snapctl set edge-proxy.extern-http-proxy=""
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -250,7 +250,10 @@ parts:
     edge-proxy:
       plugin: go
       source: git@github.com:armPelionEdge/edge-proxy.git
-      source-commit: 470539b560a9aea3c8b6ecc0c0e0d3b4064bacaf
+      source-commit: a3ffd49c387909f11b855a740230cc88c287e32e
+      override-pull: |
+        snapcraftctl pull
+        git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/patches/0001-Correctly-handle-empty-string-for-proxy-URI.patch
       go-importpath: github.com/armPelionEdge/edge-proxy
       override-build: |
         snapcraftctl build


### PR DESCRIPTION
Added patch file for edge-proxy to allow configurable external http
proxy

Signed-off-by: Kyle Stein <kyle.stein@arm.com>