### PR TITLE
v1.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,12 @@ RUN apt-get update && apt-get install -y \
 	curl jq squashfs-tools openssh-client git gosu
 
 # Install Go
-# Grab the go snap from the stable channel, unpack it in the proper place,
+# Download the go binary package, unpack it in the proper place,
 # and link the go binaries to make them available to snapcraft
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?version=1.13.5' | jq '.download_url' -r) --output go.snap && \
-	mkdir -p /snap/go && \
-	unsquashfs -d /snap/go/current go.snap && \
-	ln -sf /snap/go/current/bin/go /snap/bin/go && \
-	ln -sf /snap/go/current/bin/gofmt /snap/bin/gofmt
+RUN curl -L https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar -xz && \
+    mv go /usr/local && \
+    ln -sf /usr/local/go/bin/go /usr/local/bin/go && \
+    ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Install the script that sets up the user environment
 # and runs CMD as the current user instead of as root

--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -20,6 +20,9 @@
 # This is present on some, but not all gateways, and is where logs are persisted.
 rm -f /var/log/syslog*
 journalctl --vacuum-time=1s
+
+# Stop logging until next reboot and remove previous logs
+systemctl stop syslog.socket rsyslog.service
 find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity

--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -20,6 +20,7 @@
 # This is present on some, but not all gateways, and is where logs are persisted.
 rm -f /var/log/syslog*
 journalctl --vacuum-time=1s
+find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
 snap stop pelion-edge.kubelet || true

--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -19,11 +19,14 @@
 
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
+DEVICE_ID=$(jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/edge-proxy.conf.json)
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
 fi
-
+if ! grep -q "$DEVICE_ID" /etc/hosts; then
+    echo "127.0.0.1 $DEVICE_ID" >> /etc/hosts
+fi
 if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
     echo "edge-proxy logging is disabled.  To see logs, run \"snap set pelion-edge edge-proxy.debug=true\" and restart edge-proxy"
     # this is known as bash exec redirection.

--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -20,6 +20,11 @@ else
     NODE_IP_OPTION=""
 fi
 
+# Fix readlink permission denied in Ubuntu Core <20 for /proc/1/ns/*
+APPARMOR_PROFILE=/var/lib/snapd/apparmor/profiles/snap.${SNAP_INSTANCE_NAME}.kubelet
+sed -i 's/^\(deny ptrace\)/#\1/' $APPARMOR_PROFILE
+/sbin/apparmor_parser -r $APPARMOR_PROFILE
+
 exec ${SNAP}/wigwag/system/bin/kubelet \
     --root-dir=${SNAP_COMMON}/var/lib/kubelet \
     --offline-cache-path=${SNAP_COMMON}/var/lib/kubelet/store \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -424,7 +424,7 @@ parts:
     maestro-shell:
       plugin: go
       source: https://github.com/armPelionEdge/maestro-shell.git
-      source-commit: 04365928338093328fe86fa4d5d14231cf83d30b
+      source-commit: 405e25b1e4b9c3071d44da068109ae3d9b2519d2
       override-pull: |
         # The go plugin also tries to run go get to fetch project dependencies. We just want to use the vendored dependencies.
         # Create the go workspace. This is normally done by the plugin
@@ -436,7 +436,7 @@ parts:
         cd go/src/github.com/armPelionEdge
         git clone https://github.com/armPelionEdge/maestro-shell.git
         cd maestro-shell
-        git checkout 04365928338093328fe86fa4d5d14231cf83d30b
+        git checkout 405e25b1e4b9c3071d44da068109ae3d9b2519d2
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_BUILD}/go
         cd ${GOPATH}/src/github.com/armPelionEdge/maestro-shell/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -453,7 +453,7 @@ parts:
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git
-      source-commit: c7ea5063e533c1c5cd920cc8cd8492b509e3ac6b
+      source-commit: 1438eb113e27e044f9ba03d0d461ece3b82d32ae
       build-packages:
         - python
         - build-essential
@@ -468,7 +468,7 @@ parts:
         cd go/src/github.com/armPelionEdge
         git clone https://github.com/armPelionEdge/maestro.git
         cd maestro
-        git checkout c7ea5063e533c1c5cd920cc8cd8492b509e3ac6b
+        git checkout 1438eb113e27e044f9ba03d0d461ece3b82d32ae
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_BUILD}/go
         # Specify GOBIN so that maestro/build.sh doesn't do unexpected things

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,8 +9,8 @@ architectures:
   - amd64
 plugs:
     system-files:
-        read: [/proc, /etc, /run, /sys, /var/lib]
-        write: [/proc, /etc, /run, /var/lib]
+        read: [/proc, /etc, /run, /sys, /var/lib, /var/log]
+        write: [/proc, /etc, /run, /var/lib, /var/log]
     home:
         read: all
     support:
@@ -60,7 +60,7 @@ apps:
       restart-condition: always
       command: launch-edge-core.sh
       daemon: simple
-      plugs: [shutdown, hardware-observe, network-bind, network-control, network-observe, system-files, snapd-control]
+      plugs: [shutdown, hardware-observe, network-bind, network-control, network-observe, system-files, snapd-control, log-observe]
     edge-core-reset-storage:
       command: launch-edge-core.sh --reset-storage
       plugs: [hardware-observe, network-bind, network-control, network-observe, system-files]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: pelion-edge
 base: core
-version: "1.16.0"
+version: "1.16.1"
 summary: Pelion Edge
 description: Pelion Edge
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -564,8 +564,8 @@ parts:
         - $cni_conf
     kubelet:
       plugin: go
-      source: git@github.com:armPelionEdge/argus.git
-      source-commit: 44277f2070300ab32279298dc4217c0bd6fc0627
+      source: git@github.com:armPelionEdge/edge-kubelet.git
+      source-commit: 83b266ae6939012883611d6dbda745f2490a67c4
       go-importpath: k8s.io/kubernetes
       override-pull: |
         # The go plugin also tries to run go get to fetch project dependencies. We just want to use the vendored depdnencies.
@@ -576,9 +576,9 @@ parts:
         install -d go/pkg
         install -d go/src/k8s.io
         cd go/src/k8s.io
-        git clone git@github.com:armPelionEdge/argus.git kubernetes
+        git clone git@github.com:armPelionEdge/edge-kubelet.git kubernetes
         cd kubernetes
-        git checkout 44277f2070300ab32279298dc4217c0bd6fc0627
+        git checkout 83b266ae6939012883611d6dbda745f2490a67c4
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_SRC}/go
         cd ${GOPATH}/src/k8s.io/kubernetes/hack/make-rules


### PR DESCRIPTION
Created a `v1.16.1` branch that mirrors `dev` branch (identical history, same hashes).

Submitting PR from this branch to `master` in case `dev` moves forward in the next few hours. This is to conform to the intended git flow that I wasn't following before.

Do not merge with the Github UI! After status checks pass, will merge via command line with `git checkout master; git merge --ff-only v1.16.1`.

Release notes:
* Feature: DeviceDB running in strict mode
* Bug fix: Truncate logs during factory reset
* Bug fix: Remove ptrace apparmor restrictions for kubelet
* Bug fix: Maestro template output directory permissions updated
* Bug fix: Added DeviceID as an alias to localhost in /etc/hosts
* Bug fix: Fixed Go version locking within docker
* Bug fix: Stop syslog daemon on factory reset
* CI Improvement: Changed shared library path of maestro-shell to master
* Changed edge-kubelet repository to the correct URL