### PR TITLE
Add system-files for maestro systemd access

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,9 @@ grade: devel
 architectures:
   - amd64
 plugs:
+    system-files:
+        read: [/run/systemd/journal]
+        write: [/run/systemd/journal]
     home:
         read: all
     support:
@@ -80,7 +83,7 @@ apps:
         restart-delay: 5s
       restart-condition: always
       daemon: simple
-      plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, mount-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, x11]
+      plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, mount-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, x11, system-files]
     maestro-shell:
       command: wigwag/system/bin/maestro-shell
       environment:


### PR DESCRIPTION
There is no suitable suggestion offered by snappy-debug as a
replacement for accessing /run/systemd/journal in write mode.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>