### PR TITLE
Change grade to stable for easy snap store publishing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ version: "1.16.0"
 summary: Pelion Edge
 description: Pelion Edge
 confinement: strict
-grade: devel
+grade: stable
 architectures:
   - amd64
 plugs:


### PR DESCRIPTION
In order to publish on the stable/candidate release tracks, the grade
must be stable.  Devel grade can only be publised to edge/beta tracks.