### PR TITLE
Enable snapd managed updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,9 @@ grade: stable
 architectures:
   - amd64
 plugs:
+    snapd:
+        interface: snapd-control
+        refresh-schedule: managed
     system-files-logs:
         interface: system-files
         read:


### PR DESCRIPTION
We launch snap install/refresh via Pelion update(FOTA).  So disable
snapd automatic updates using the snapd managed updates feature.