### PR TITLE
explicitly rename system-files plug to system-files-logs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,8 @@ grade: stable
 architectures:
   - amd64
 plugs:
-    system-files:
+    system-files-logs:
+        interface: system-files
         read:
           - /run/systemd/journal
           - /run/systemd/private


### PR DESCRIPTION
it's best practice to give a descriptive plug name since we're
specifying multiple attributes.