### PR TITLE
explicitly rename system-files plug to system-files-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
     sudo snap connect pelion-edge:firewall-control :firewall-control
     sudo snap connect pelion-edge:docker-cli pelion-edge:docker-daemon
     sudo snap connect pelion-edge:log-observe :log-observe
-    sudo snap connect pelion-edge:system-files :system-files
+    sudo snap connect pelion-edge:system-files-logs :system-files
     sudo snap connect pelion-edge:kernel-module-observe :kernel-module-observe
     sudo snap connect pelion-edge:system-trace :system-trace
     sudo snap connect pelion-edge:system-observe :system-observe

--- a/connect.sh
+++ b/connect.sh
@@ -26,7 +26,7 @@ sudo snap connect pelion-edge:support             :docker-support
 sudo snap connect pelion-edge:firewall-control    :firewall-control
 sudo snap connect pelion-edge:docker-cli          pelion-edge:docker-daemon
 sudo snap connect pelion-edge:log-observe         :log-observe
-sudo snap connect pelion-edge:system-files        :system-files
+sudo snap connect pelion-edge:system-files-logs   :system-files
 sudo snap connect pelion-edge:kernel-module-observe :kernel-module-observe
 sudo snap connect pelion-edge:system-trace        :system-trace
 sudo snap connect pelion-edge:system-observe      :system-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,8 @@ grade: stable
 architectures:
   - amd64
 plugs:
-    system-files:
+    system-files-logs:
+        interface: system-files
         read:
           - /run/systemd/journal
           - /run/systemd/private
@@ -83,7 +84,7 @@ apps:
         - process-control
         - snapd-control
         - shutdown
-        - system-files
+        - system-files-logs
     edge-core-reset-storage:
       command: launch-edge-core.sh --reset-storage
       plugs: [hardware-observe, network-bind, network-control, network-observe]
@@ -104,7 +105,7 @@ apps:
         restart-delay: 5s
       restart-condition: always
       daemon: simple
-      plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, mount-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, x11, system-files]
+      plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, mount-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, x11, system-files-logs]
     maestro-shell:
       command: wigwag/system/bin/maestro-shell
       environment:
@@ -145,7 +146,7 @@ apps:
         - network-observe
         - process-control
         - support
-        - system-files
+        - system-files-logs
         - system-observe
         - system-trace
     docker:


### PR DESCRIPTION
it's best practice to give a descriptive plug name since we're
specifying multiple attributes.