### PR TITLE
Cleanup install hook

### DIFF
--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -44,6 +44,12 @@ done
 rm -rf "$dir"
 trap - EXIT
 
+# copy the config file from $SNAP into $SNAP_COMMON if it doesn't exist
+if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
+    mkdir -p "$SNAP_DATA/config"
+    cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
+fi
+
 # use SNAP_COMMON for most "data" bits
 mkdir -p "$SNAP_COMMON/var/run/docker"
 

--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -53,6 +53,9 @@ fi
 # use SNAP_COMMON for most "data" bits
 mkdir -p "$SNAP_COMMON/var/run/docker"
 
+# ensure the layouts dir for /etc/docker exists
+mkdir -p "$SNAP_DATA/etc/docker"
+
 workaround_lp1606510
 
 workaround_apparmor_profile_reload

--- a/files/edge-core/scripts/launch-edge-core.sh
+++ b/files/edge-core/scripts/launch-edge-core.sh
@@ -23,6 +23,11 @@ if [ ! -d ${SNAP_DATA}/userdata/mbed ]; then
     mkdir -p ${SNAP_DATA}/userdata/mbed
 fi
 
+# make sure the upgrade folder exists in case we need to download updates
+if [ ! -d "$SNAP_DATA/upgrades" ]; then
+    mkdir -p $SNAP_DATA/upgrades
+fi
+
 # before we start edge-core, call the fake bootloader to apply any existing updates
 ${SNAP}/edge-core-bootloader.sh
 

--- a/files/edge-core/scripts/launch-edge-core.sh
+++ b/files/edge-core/scripts/launch-edge-core.sh
@@ -28,6 +28,9 @@ ${SNAP}/edge-core-bootloader.sh
 
 # SNAP_DATA: /var/snap/pelion-edge/current/
 CONF_FILE=${SNAP_DATA}/edge-core.conf
+if [ ! -f "${CONF_FILE}" ]; then
+    cp "$SNAP/edge-core.conf" "${CONF_FILE}"
+fi
 
 # defaults
 ARGS=""

--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -17,30 +17,36 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+if [ ! -f "$SNAP_DATA/edge-proxy.conf.json" ]; then
+    cp "$SNAP/edge-proxy.conf.json" "$SNAP_DATA/edge-proxy.conf.json"
+fi
+
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 DEVICE_ID=$(jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/edge-proxy.conf.json)
 EXTERN_HTTP_PROXY=$(snapctl get edge-proxy.extern-http-proxy)
+
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
 fi
+
 if ! grep -q "$DEVICE_ID" /etc/hosts; then
     echo "127.0.0.1 $DEVICE_ID" >> /etc/hosts
 fi
+
 if [[ $EXTERN_HTTP_PROXY = "" ]]; then
     EXTERN_ARG=
 else
     EXTERN_ARG=-extern-http-proxy-uri=$EXTERN_HTTP_PROXY
 fi
+
 if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
     echo "edge-proxy logging is disabled.  To see logs, run \"snap set pelion-edge edge-proxy.debug=true\" and restart edge-proxy"
     # this is known as bash exec redirection.
     # see https://www.tldp.org/LDP/abs/html/x17974.html
     exec >/dev/null 2>&1
 fi
-
-
 
 exec ${SNAP}/wigwag/system/bin/edge-proxy \
     -proxy-uri=${EDGE_K8S_ADDRESS} \

--- a/files/maestro/launch-maestro.sh
+++ b/files/maestro/launch-maestro.sh
@@ -4,4 +4,8 @@ if [ ! -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json ]; then
     exit 1
 fi
 
+if [ ! -d "$SNAP_DATA/wigwag/log" ]; then
+    mkdir -p $SNAP_DATA/wigwag/log
+fi
+
 exec ${SNAP}/wigwag/system/bin/maestro -config $SNAP_DATA/maestro-config.yaml

--- a/files/maestro/launch-maestro.sh
+++ b/files/maestro/launch-maestro.sh
@@ -8,4 +8,8 @@ if [ ! -d "$SNAP_DATA/wigwag/log" ]; then
     mkdir -p $SNAP_DATA/wigwag/log
 fi
 
+if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
+    mkdir -p $SNAP_DATA/userdata/etc
+fi
+
 exec ${SNAP}/wigwag/system/bin/maestro -config $SNAP_DATA/maestro-config.yaml

--- a/files/maestro/launch-maestro.sh
+++ b/files/maestro/launch-maestro.sh
@@ -12,4 +12,8 @@ if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
     mkdir -p $SNAP_DATA/userdata/etc
 fi
 
+if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
+    cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
+fi
+
 exec ${SNAP}/wigwag/system/bin/maestro -config $SNAP_DATA/maestro-config.yaml

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,10 +17,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
-    cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
-fi
-
 # disable auto-start on some services.
 # as of snapcraft v3.8, services can't be configured to be disabled by default
 # in snapcraft.yaml and must instead be disabled in the install hook.

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,10 +17,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-if [ ! -f "$SNAP_DATA/edge-proxy.conf.json" ]; then
-    cp "$SNAP/edge-proxy.conf.json" "$SNAP_DATA/edge-proxy.conf.json"
-fi
-
 if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
     mkdir -p $SNAP_DATA/userdata/etc
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -33,10 +33,6 @@ if [ ! -d "$SNAP_DATA/wigwag/log" ]; then
     mkdir -p $SNAP_DATA/wigwag/log
 fi
 
-if [ ! -d "$SNAP_DATA/upgrades" ]; then
-    mkdir -p $SNAP_DATA/upgrades
-fi
-
 # copy the config file from $SNAP into $SNAP_COMMON if it doesn't exist
 if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     mkdir -p "$SNAP_DATA/config"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,10 +17,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-if [ ! -f "$SNAP_DATA/edge-core.conf" ]; then
-    cp "$SNAP/edge-core.conf" "$SNAP_DATA/edge-core.conf"
-fi
-
 if [ ! -f "$SNAP_DATA/edge-proxy.conf.json" ]; then
     cp "$SNAP/edge-proxy.conf.json" "$SNAP_DATA/edge-proxy.conf.json"
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -25,10 +25,6 @@ if [ ! -d "$SNAP_DATA/localdata" ]; then
     mkdir -p $SNAP_DATA/localdata
 fi
 
-if [ ! -d "$SNAP_DATA/wigwag/log" ]; then
-    mkdir -p $SNAP_DATA/wigwag/log
-fi
-
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -33,12 +33,6 @@ if [ ! -d "$SNAP_DATA/wigwag/log" ]; then
     mkdir -p $SNAP_DATA/wigwag/log
 fi
 
-# copy the config file from $SNAP into $SNAP_COMMON if it doesn't exist
-if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
-    mkdir -p "$SNAP_DATA/config"
-    cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
-fi
-
 # ensure the layouts dir for /etc/docker exists
 mkdir -p "$SNAP_DATA/etc/docker"
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -33,9 +33,6 @@ if [ ! -d "$SNAP_DATA/wigwag/log" ]; then
     mkdir -p $SNAP_DATA/wigwag/log
 fi
 
-# ensure the layouts dir for /etc/docker exists
-mkdir -p "$SNAP_DATA/etc/docker"
-
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,10 +17,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
-    mkdir -p $SNAP_DATA/userdata/etc
-fi
-
 if [ ! -d "$SNAP_DATA/localdata" ]; then
     mkdir -p $SNAP_DATA/localdata
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,10 +17,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-if [ ! -d "$SNAP_DATA/localdata" ]; then
-    mkdir -p $SNAP_DATA/localdata
-fi
-
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
 fi


### PR DESCRIPTION
Move file copy and directory creation out of the install hook and into the individual component launch scripts that require it.  This should help pelion-edge recover from accidental (or otherwise) deletion of SNAP_DATA.