### PR TITLE
Clear devicedb on factory-reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -26,6 +26,8 @@ systemctl stop syslog.socket rsyslog.service
 find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
+rm -rf ${SNAP_DATA}/userdata/etc/devicedb
+rm -rf ${SNAP_DATA}/wigwag/etc/devicejs/devicedb.yaml
 snap stop pelion-edge.kubelet || true
 rm -rf ${SNAP_COMMON}/var/lib/kubelet
 


### PR DESCRIPTION
* Remove the devicedb data store on a factory reset
* Remove the devicedb input config on a factory reset.
  * Maestro will re-create the config on first boot after the reset