### PR TITLE
explicitly disable devicedb

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ This repository contains snapcraft packaging for Pelion Edge on Ubuntu.
     sudo snap install --dangerous pelion-edge_<version>_<arch>.snap
     ```
 
+1. Disable devicedb
+
+    ```bash
+    sudo systemctl stop snap.pelion-edge.devicedb.service
+    sudo systemctl disable snap.pelion-edge.devicedb.service
+    ```
+
 1. Hookup the following connections
 
     ```bash


### PR DESCRIPTION
Lots of CPU is being consumed by systemd constantly trying to start
devicedb.  It's also causing lots of pointless network traffic.
devicedb doesn't have a valid config file currently right now which is
why it won't start.  So, explicitly disable devicedb for now so that
systemd doesn't keep trying to start it.