### PR TITLE
Remove instructions to install snap in devmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Example runme.sh script:
 #!/bin/bash
 set -eux
 
-snap install --devmode pelion-edge_1.0_amd64.snap
+snap install --dangerous pelion-edge_1.0_amd64.snap
 ```
 
 This example `runme.sh` script assumes a firmware update tar.gz with the following contents:
@@ -333,12 +333,12 @@ $ tar -tzf firmware-update.tar.gz`
     ```
     snap ack curl.assert
     snap install curl.snap
-    snap install --devmode pelion-edge_amd64.snap
+    snap install --dangerous pelion-edge_amd64.snap
     ```
 
     not this:
     ```
-    snap install --devmode pelion-edge_amd64.snap
+    snap install --dangerous pelion-edge_amd64.snap
     snap ack curl.assert
     snap install curl.snap
     ```

--- a/docs/relayterm.md
+++ b/docs/relayterm.md
@@ -7,21 +7,21 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
 
 2. Install the snap:
   ```
-  $ sudo snap install pelion-edge_1.5_amd64_con_dev.snap –devmode
+  $ sudo snap install pelion-edge_1.5_amd64_con_dev.snap –dangerous
   ```
-  
+
 3. Restart maestro after you are sure it registered to Pelion:
   ```
   $ sudo snap restart pelion-edge.maestro
   ```
-  
+
 4. Make the connections to allow nmcli, mmcli and snap to work in the remote terminal.
   ```
   $ sudo snap connect pelion-edge:snapd-control :snapd-control
   $ sudo snap connect pelion-edge:modem-manager modem-manager:service
   $ sudo snap connect pelion-edge:network-manager network-manager:service
   ```
-  
+
 5. Open the terminal in the Pelion portal and verify that nmcli, mmcli and snap commands work.  NOTE: The edge features must be enabled on your Pelion account to see the remote terminal tab.
 
-The restart for maestro is due to a race condition with the credential generation for the terminal feature after the device bootstraps the first time.  I did not find a quick fix other than to restart maestro after the device bootstraps in order to generate the remote terminal creds in ".ssl" path..  
+The restart for maestro is due to a race condition with the credential generation for the terminal feature after the device bootstraps the first time.  I did not find a quick fix other than to restart maestro after the device bootstraps in order to generate the remote terminal creds in ".ssl" path..

--- a/update/runme.sh
+++ b/update/runme.sh
@@ -13,5 +13,5 @@
 set -eux
 
 echo "START runme.sh"
-snap install --devmode pelion-edge_1.0_amd64.snap
+snap install --dangerous pelion-edge_1.0_amd64.snap
 echo "END runme.sh"


### PR DESCRIPTION
Since strict confinement is the officially supported confinement mode,
we remove instructions to install with --devmode in order to remove
confusion.