### PR TITLE
Enable DeviceDB for remote config management

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -337,7 +337,7 @@ parts:
         - python
         - build-essential
       source: https://github.com/armPelionEdge/edge-utils.git
-      source-commit: 7020d6bd0d3a486299d33e20be3f11b61372ebeb
+      source-commit: 0159e6dc719c8552838de238f65fd68075523a0f
       override-pull: |
         snapcraftctl pull
         cp ${SNAPCRAFT_PROJECT_DIR}/files/wwrelay-utils/package.json .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -337,7 +337,7 @@ parts:
         - python
         - build-essential
       source: https://github.com/armPelionEdge/edge-utils.git
-      source-commit: 0159e6dc719c8552838de238f65fd68075523a0f
+      source-commit: d751f0394e7b7feff12f04ee85a7915b7eecb796
       override-pull: |
         snapcraftctl pull
         cp ${SNAPCRAFT_PROJECT_DIR}/files/wwrelay-utils/package.json .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -494,7 +494,7 @@ parts:
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git
-      source-commit: a2069b14dd636af3ca7069dcb3bbd18a6fa37db9
+      source-commit: 300fcdf67616f4018f0f2b53db4b88c54a333e1b
       build-packages:
         - python
         - build-essential
@@ -509,7 +509,7 @@ parts:
         cd go/src/github.com/armPelionEdge
         git clone https://github.com/armPelionEdge/maestro.git
         cd maestro
-        git checkout a2069b14dd636af3ca7069dcb3bbd18a6fa37db9
+        git checkout 300fcdf67616f4018f0f2b53db4b88c54a333e1b
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_BUILD}/go
         # Specify GOBIN so that maestro/build.sh doesn't do unexpected things


### PR DESCRIPTION
Updating snap-pelion-edge to have devicedb logging functionality from the cloud.