### PR TITLE
Remove maestro managed interfaces from nmcli managed interfaces

### DIFF
--- a/files/maestro/launch-maestro.sh
+++ b/files/maestro/launch-maestro.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 if [ ! -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json ]; then
     echo "identity.json does not exist"
@@ -14,6 +15,25 @@ fi
 
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
+fi
+
+config_file=$SNAP_DATA/maestro-config.yaml
+
+networking_disabled=$($SNAP/bin/yq r $config_file network.disable)
+
+if [ "$networking_disabled" != "true" ]; then
+
+	# Obtain interfaces maestro is managing
+	interfaces=$($SNAP/bin/yq r $config_file network.interfaces.*.if_name)
+
+	# If interfaces found, turn of nmcli management of said interfaces
+	[ $? = 0 ] && for i in $interfaces; do
+	    $SNAP/bin/nmcli dev set $i managed no
+	done
+
+	# @todo: turn on management of previous interfaces that were disabled
+	#        and are no longer managed by maestro
+
 fi
 
 exec ${SNAP}/wigwag/system/bin/maestro -config $SNAP_DATA/maestro-config.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -491,6 +491,10 @@ parts:
         # copied into the prime directory during the prime step
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
         install ${GOPATH}/bin/maestro-shell ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/maestro-shell
+    yq:
+      plugin: go
+      source: git@github.com:mikefarah/yq.git
+      go-importpath: github.com/mikefarah/yq
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git


### PR DESCRIPTION
We must make sure nmcli does not manage any interface that
maestro manages, otherwise the network will be unstable.

Added yq to maestro dependencies so that the maestro init script
can parse the names of managed network interfaces from the maestro
config file.

Add network-manager plug to maestro so that maestro can configure
nmcli to ignore interfaces managed by maestro.