### PR TITLE
Remove unused packages: dss and openssl-1.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -447,12 +447,6 @@ parts:
         - $devtools
         - $system
         - $support
-    dss:
-      plugin: dump
-      source: https://github.com/armPelionEdge/edgeos-shell-scripts.git
-      source-commit: 04db833a43b80ecdfae07fd388bbe4e242771f38
-      organize:
-        '*': wigwag/system/bin/
     openssl10:
       plugin: make
       make-install-var: "INSTALL_PREFIX"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -447,15 +447,6 @@ parts:
         - $devtools
         - $system
         - $support
-    openssl10:
-      plugin: make
-      make-install-var: "INSTALL_PREFIX"
-      source: https://github.com/openssl/openssl/archive/OpenSSL_1_0_2u.tar.gz
-      source-checksum: md5/c38577624507dad3a4a1f3d07b84fa59
-      override-build: |
-        ./config shared
-        make depend
-        snapcraftctl build
     maestro-shell:
       plugin: go
       source: https://github.com/armPelionEdge/maestro-shell.git


### PR DESCRIPTION
These packages don't seem to be used in snap-pelion-edge and also aren't used by the ubuntu-pelion-edge project.