### PR TITLE
Remove hard-coded snap name in scripts for easier snap renaming

### DIFF
--- a/connect.sh
+++ b/connect.sh
@@ -17,26 +17,28 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-sudo snap connect pelion-edge:snapd-control       :snapd-control
-sudo snap connect pelion-edge:modem-manager       modem-manager:service
-sudo snap connect pelion-edge:network-manager     network-manager:service
-sudo snap connect pelion-edge:network-control     :network-control
-sudo snap connect pelion-edge:privileged          :docker-support
-sudo snap connect pelion-edge:support             :docker-support
-sudo snap connect pelion-edge:firewall-control    :firewall-control
-sudo snap connect pelion-edge:docker-cli          pelion-edge:docker-daemon
-sudo snap connect pelion-edge:log-observe         :log-observe
-sudo snap connect pelion-edge:system-files-logs   :system-files
-sudo snap connect pelion-edge:kernel-module-observe :kernel-module-observe
-sudo snap connect pelion-edge:system-trace        :system-trace
-sudo snap connect pelion-edge:system-observe      :system-observe
-sudo snap connect pelion-edge:account-control     :account-control
-sudo snap connect pelion-edge:bluetooth-control   :bluetooth-control
-sudo snap connect pelion-edge:hardware-observe    :hardware-observe
-sudo snap connect pelion-edge:kubernetes-support  :kubernetes-support
-sudo snap connect pelion-edge:mount-observe       :mount-observe
-sudo snap connect pelion-edge:netlink-audit       :netlink-audit
-sudo snap connect pelion-edge:netlink-connector   :netlink-connector
-sudo snap connect pelion-edge:network-observe     :network-observe
-sudo snap connect pelion-edge:process-control     :process-control
-sudo snap connect pelion-edge:shutdown            :shutdown
+SNAP_NAME=${SNAP_NAME:-pelion-edge}
+
+sudo snap connect ${SNAP_NAME}:snapd-control       :snapd-control
+sudo snap connect ${SNAP_NAME}:modem-manager       modem-manager:service
+sudo snap connect ${SNAP_NAME}:network-manager     network-manager:service
+sudo snap connect ${SNAP_NAME}:network-control     :network-control
+sudo snap connect ${SNAP_NAME}:privileged          :docker-support
+sudo snap connect ${SNAP_NAME}:support             :docker-support
+sudo snap connect ${SNAP_NAME}:firewall-control    :firewall-control
+sudo snap connect ${SNAP_NAME}:docker-cli          ${SNAP_NAME}:docker-daemon
+sudo snap connect ${SNAP_NAME}:log-observe         :log-observe
+sudo snap connect ${SNAP_NAME}:system-files-logs   :system-files
+sudo snap connect ${SNAP_NAME}:kernel-module-observe :kernel-module-observe
+sudo snap connect ${SNAP_NAME}:system-trace        :system-trace
+sudo snap connect ${SNAP_NAME}:system-observe      :system-observe
+sudo snap connect ${SNAP_NAME}:account-control     :account-control
+sudo snap connect ${SNAP_NAME}:bluetooth-control   :bluetooth-control
+sudo snap connect ${SNAP_NAME}:hardware-observe    :hardware-observe
+sudo snap connect ${SNAP_NAME}:kubernetes-support  :kubernetes-support
+sudo snap connect ${SNAP_NAME}:mount-observe       :mount-observe
+sudo snap connect ${SNAP_NAME}:netlink-audit       :netlink-audit
+sudo snap connect ${SNAP_NAME}:netlink-connector   :netlink-connector
+sudo snap connect ${SNAP_NAME}:network-observe     :network-observe
+sudo snap connect ${SNAP_NAME}:process-control     :process-control
+sudo snap connect ${SNAP_NAME}:shutdown            :shutdown

--- a/files/docker/bin/prep-docker-build.sh
+++ b/files/docker/bin/prep-docker-build.sh
@@ -6,7 +6,7 @@
 
 for patch in "$SNAPCRAFT_STAGE"/patches/*.patch; do
 	echo "Applying $(basename "$patch") ..."
-	git apply --ignore-space-change --ignore-whitespace "$patch"
+	sed "s/pelion-edge/${SNAPCRAFT_PROJECT_NAME}/g" "$patch" | git apply --ignore-space-change --ignore-whitespace -
 	echo
 done
 

--- a/files/edge-core/cmake/target.cmake
+++ b/files/edge-core/cmake/target.cmake
@@ -3,9 +3,12 @@ SET (OS_BRAND Linux)
 SET (MBED_CLOUD_CLIENT_DEVICE x86_x64)
 SET (PAL_TARGET_DEVICE x86_x64)
 
-SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/var/snap/pelion-edge/current/userdata/mbed/mcc_config\"")
-SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/var/snap/pelion-edge/current/userdata/mbed/mcc_config\"")
-SET (PAL_UPDATE_FIRMWARE_DIR "\"/var/snap/pelion-edge/current/upgrades\"")
+MESSAGE ("Using SNAPCRAFT_PROJECT_NAME: $ENV{SNAPCRAFT_PROJECT_NAME}")
+add_definitions ("-DSNAPCRAFT_PROJECT_NAME=\"$ENV{SNAPCRAFT_PROJECT_NAME}\"")
+
+SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/var/snap/$ENV{SNAPCRAFT_PROJECT_NAME}/current/userdata/mbed/mcc_config\"")
+SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/var/snap/$ENV{SNAPCRAFT_PROJECT_NAME}/current/userdata/mbed/mcc_config\"")
+SET (PAL_UPDATE_FIRMWARE_DIR "\"/var/snap/$ENV{SNAPCRAFT_PROJECT_NAME}/current/upgrades\"")
 SET (PAL_USER_DEFINED_CONFIGURATION "\"${CMAKE_CURRENT_SOURCE_DIR}/config/sotp_fs_linux.h\"")
 
 if (${FIRMWARE_UPDATE})

--- a/files/edge-core/patches/0001-use-customized-edge-core-update-scripts.patch
+++ b/files/edge-core/patches/0001-use-customized-edge-core-update-scripts.patch
@@ -1,14 +1,14 @@
-From 6696df8a7c633ec64f902a10bf1b05947c0fa095 Mon Sep 17 00:00:00 2001
+From 691093985f83fce9f6c70da15ba731877669fc9b Mon Sep 17 00:00:00 2001
 From: Nic Costa <nic.costa@gmail.com>
 Date: Thu, 2 Apr 2020 16:37:10 -0500
-Subject: [PATCH] use customized edge-core update scripts
+Subject: [PATCH 1/8] use customized edge-core update scripts
 
 ---
- .../source/arm_uc_pal_linux_generic.c          | 18 +++++++++---------
+ .../pal-linux/source/arm_uc_pal_linux_generic.c        | 18 +++++++++---------
  1 file changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_generic.c b/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_generic.c
-index 1d1228b..872f101 100644
+index 4f7c0be..09d623d 100644
 --- a/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_generic.c
 +++ b/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_generic.c
 @@ -121,7 +121,7 @@ arm_ucp_worker_t arm_uc_worker_parameters_details = {
@@ -16,7 +16,7 @@ index 1d1228b..872f101 100644
  
  arm_ucp_worker_t arm_uc_worker_parameters_active_details = {
 -    .command = "../../../arm_update_active_details.sh",
-+    .command = "/snap/pelion-edge/current/wigwag/mbed/arm_update_active_details.sh",
++    .command = "/snap/" SNAPCRAFT_PROJECT_NAME "/current/wigwag/mbed/arm_update_active_details.sh",
      .header   = 1,
      .firmware = 0,
      .location = 0,
@@ -25,7 +25,7 @@ index 1d1228b..872f101 100644
  
  arm_ucp_worker_t arm_uc_worker_parameters_activate = {
 -    .command = "../../../arm_update_activate.sh",
-+    .command = "/snap/pelion-edge/current/wigwag/mbed/arm_update_activate.sh",
++    .command = "/snap/" SNAPCRAFT_PROJECT_NAME "/current/wigwag/mbed/arm_update_activate.sh",
      .header   = 1,
      .firmware = 1,
      .location = 0,
@@ -34,7 +34,7 @@ index 1d1228b..872f101 100644
  
  arm_ucp_worker_t arm_uc_worker_parameters_installer = {
 -    .command = "../../../arm_update_installer.sh",
-+    .command = "/snap/pelion-edge/current/wigwag/mbed/arm_update_installer.sh",
++    .command = "/snap/" SNAPCRAFT_PROJECT_NAME "/current/wigwag/mbed/arm_update_installer.sh",
      .header   = 1,
      .firmware = 0,
      .location = 0,
@@ -59,5 +59,5 @@ index 1d1228b..872f101 100644
  
      return ARM_UC_PAL_Linux_Initialize(callback);
 -- 
-2.21.0 (Apple Git-122)
+2.7.4
 

--- a/files/edge-core/patches/0003-Broadcast-gateway-stats-to-LWM2M-resources.patch
+++ b/files/edge-core/patches/0003-Broadcast-gateway-stats-to-LWM2M-resources.patch
@@ -1,7 +1,7 @@
-From 08fd5a973e423e2c968cf60d2652fa86fb05bd63 Mon Sep 17 00:00:00 2001
+From b9bd33f47e5d978caa22d4b262e303967d4008cf Mon Sep 17 00:00:00 2001
 From: Michael Ray <mjray@umich.edu>
 Date: Thu, 25 Jun 2020 13:50:22 -0500
-Subject: [PATCH 3/3] Broadcast gateway stats to LWM2M resources
+Subject: [PATCH 5/8] Broadcast gateway stats to LWM2M resources
 
 List of resources broadcasting:
 * /3/0/3303 - CPU temp
@@ -155,7 +155,7 @@ index 5b22e85..479658c 100644
                                                        const uint16_t object_id,
                                                        const uint16_t object_instance_id,
 diff --git a/edge-client/gateway_services_resource.c b/edge-client/gateway_services_resource.c
-index 3149dd5..253396b 100644
+index 3149dd5..800c052 100644
 --- a/edge-client/gateway_services_resource.c
 +++ b/edge-client/gateway_services_resource.c
 @@ -22,9 +22,24 @@
@@ -459,7 +459,7 @@ index 3149dd5..253396b 100644
 +    float float_default = 0;
  
 +    // bash command to fetch data
-+    const char cmd_version[] = "snap info pelion-edge | sed -n 's/^installed:[^0-9]*\\([0-9.]*\\).*/\\1/p'";    //snap version
++    const char cmd_version[] = "snap info " SNAPCRAFT_PROJECT_NAME " | sed -n 's/^installed:[^0-9]*\\([0-9.]*\\).*/\\1/p'";    //snap version
 +    const char cmd_ram_total[] = "awk '/^MemTotal:/{ print $2*1024 }' /proc/meminfo";                           //ram total
 +    const char cmd_disk_total[] = "df /home --output=size | sed '$!d;s/ *//'"; //disk total
 +
@@ -564,5 +564,5 @@ index 0477bb7..e86892c 100644
  }
 -
 -- 
-2.10.1.windows.1
+2.7.4
 

--- a/files/edge-core/scripts/arm_update_cmdline.sh
+++ b/files/edge-core/scripts/arm_update_cmdline.sh
@@ -20,8 +20,6 @@
 # This script is used for firmware upgrades. It parses the command line in
 # order to allow environment and command line parameter merging
 
-# SNAP_DATA: /var/snap/pelion-edge/current/
-# path copied from snap-pelion-edge/snap/hooks/install
 UPGRADE_DIR="${SNAP_DATA}/upgrades"
 UPGRADE_TGZ="${UPGRADE_DIR}/upgrade.tar.gz"
 UPGRADE_HDR="${UPGRADE_DIR}/header.bin"

--- a/files/edge-core/scripts/edge-core-bootloader.sh
+++ b/files/edge-core/scripts/edge-core-bootloader.sh
@@ -21,8 +21,6 @@
 # upgrade.tar.gz file in ${SNAP_DATA}/upgrades/, and if found, untars the file
 # and runs the runme.sh script inside.
 
-# SNAP_DATA: /var/snap/pelion-edge/current/
-# path copied from snap-pelion-edge/snap/hooks/install
 UPGRADE_DIR=${SNAP_DATA}/upgrades
 UPGRADE_TGZ=${UPGRADE_DIR}/upgrade.tar.gz
 UPGRADE_HDR=${UPGRADE_DIR}/header.bin

--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -28,7 +28,7 @@ find /var/log -type f -print0 | xargs -0 truncate --size=0
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
 rm -rf ${SNAP_DATA}/userdata/etc
 rm -rf ${SNAP_DATA}/wigwag/etc/devicejs/devicedb.yaml
-snap stop pelion-edge.kubelet || true
+snap stop ${SNAP_INSTANCE_NAME}.kubelet || true
 rm -rf ${SNAP_COMMON}/var/lib/kubelet
 
 # Stop and remove all existing docker containers and images

--- a/files/edge-core/scripts/launch-edge-core.sh
+++ b/files/edge-core/scripts/launch-edge-core.sh
@@ -31,7 +31,6 @@ fi
 # before we start edge-core, call the fake bootloader to apply any existing updates
 ${SNAP}/edge-core-bootloader.sh
 
-# SNAP_DATA: /var/snap/pelion-edge/current/
 CONF_FILE=${SNAP_DATA}/edge-core.conf
 if [ ! -f "${CONF_FILE}" ]; then
     cp "$SNAP/edge-core.conf" "${CONF_FILE}"

--- a/files/edge-core/src/mbed_cloud_client_user_config.h
+++ b/files/edge-core/src/mbed_cloud_client_user_config.h
@@ -43,7 +43,7 @@
 
 #define EDGE_RUNNING_IN_SNAP 1
 
-#define PLATFORM_VERSION_FILE "/var/snap/pelion-edge/current/etc/platform_version"
+#define PLATFORM_VERSION_FILE "/var/snap/" SNAPCRAFT_PROJECT_NAME "/current/etc/platform_version"
 
 #endif /* MBED_CLIENT_USER_CONFIG_H */
 

--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -42,7 +42,7 @@ else
 fi
 
 if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
-    echo "edge-proxy logging is disabled.  To see logs, run \"snap set pelion-edge edge-proxy.debug=true\" and restart edge-proxy"
+    echo "edge-proxy logging is disabled.  To see logs, run \"snap set ${SNAP_INSTANCE_NAME} edge-proxy.debug=true\" and restart edge-proxy"
     # this is known as bash exec redirection.
     # see https://www.tldp.org/LDP/abs/html/x17974.html
     exec >/dev/null 2>&1

--- a/files/maestro/config/maestro-config-dell5000.yaml
+++ b/files/maestro/config/maestro-config-dell5000.yaml
@@ -1,0 +1,191 @@
+unixLogSocket: /tmp/grease.socket
+sysLogSocket: /run/systemd/journal/syslog
+linuxKernelLog: false
+httpUnixSocket: /tmp/maestroapi.sock
+configDBPath: "{{SNAP_DATA}}/userdata/etc/maestroConfig.db"
+imagePath: /tmp/maestro/images
+scratchPath: /tmp/maestro/scratch
+clientId: "{{ARCH_SERIAL_NUMBER}}"
+network:
+    disable: true
+platform_readers:
+  - platform: "fsonly"
+    params:
+      identityPath: "/var/snap/pelion-edge/current/userdata/edge_gw_identity/identity.json"
+var_defs:
+   - key: "SNAP_DATA"
+     value: "/var/snap/pelion-edge/current"
+   - key: "SNAP"
+     value: "/snap/pelion-edge/current"
+   - key: "TMP_DIR"
+     value: "/tmp"
+   - key: "WIGWAG_NODE_PATH"
+     value: "{{SNAP}}/wigwag/devicejs-core-modules/node_modules"
+   - key: "WIGWAG_DIR"
+     value: "{{SNAP}}/wigwag"
+   - key: "NODE_EXEC"
+     value: "{{SNAP}}/wigwag/system/bin/node"
+   - key: "MAESTRO_RUNNER_DIR"
+     value: "{{SNAP}}/wigwag/devicejs-core-modules/maestroRunner"
+   - key: "SSL_CERTS_PATH"
+     value: "{{SNAP_DATA}}/userdata/edge_gw_identity/.ssl"
+   - key: "LOCAL_DEVICEDB_PORT"
+     value: 9000
+   - key: "LOCAL_DATABASE_STORAGE_DIRECTORY"
+     value: "{{SNAP_DATA}}/userdata/etc/devicedb/db"
+   - key: "RELAY_VERSIONS_FILE"
+     value: "{{SNAP}}/wigwag/etc/versions.json"
+   - key: "FACTORY_VERSIONS_FILE"
+     value: "{{SNAP}}/wigwag/etc/versions.json"
+   - key: "USER_VERSIONS_FILE"
+     value: "{{SNAP}}/wigwag/etc/versions.json"
+   - key: "UPGRADE_VERSIONS_FILE"
+     value: "{{SNAP}}/wigwag/etc/versions.json"
+mdns:
+  # disable: true
+  static_records:
+   - name: "WigWagRelay"
+     service: "_wwservices._tcp"  # normally something like https or ftp
+     # domain: "local"     # local is default
+     interfaces: "eth0"
+     not_interfaces: "Witap0"
+     port: 3131
+     text:
+      - "wwid={{ARCH_SERIAL_NUMBER}}"
+     hostname: "wigwaggateway"
+   - name: "WigWagRelay_{{ARCH_SERIAL_NUMBER}}"
+     service: "_wwservices._tcp"  # normally something like https or ftp
+     # domain: "local"     # local is default
+     interfaces: "eth0"
+     not_interfaces: "Witap0"
+     port: 3131
+     text:
+      - "wwid={{ARCH_SERIAL_NUMBER}}"
+     hostname: "{{ARCH_SERIAL_NUMBER}}"
+symphony:
+# symphony system management APIs
+    # defaults to 10:
+    disable_sys_stats: true
+    sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
+    sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
+    #client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
+    #client_key: "{{ARCH_CLIENT_KEY_PEM}}"
+    no_tls: true
+    host: "gateways.local"
+    url_logs: "http://gateways.local:8080/relay-logs/logs"
+    url_stats: "http://gateways.local:8080/relay-stats/stats_obj"
+    send_time_threshold: 120000       # set the send time threshold to 2 minutes
+    # port: "{{ARCH_RELAY_SERVICES_PORT}}"
+targets:
+   - file: "{{SNAP_DATA}}/userdata/maestro.log"
+     rotate:
+         max_files: 4
+         max_file_size: 10000000  # 10MB max file size
+         max_total_size: 42000000
+         rotate_on_start: true
+     delim: "\n"
+     format_time: "[%ld:%d] "
+     format_level: "<%s> "
+     format_tag: "{%s} "
+     format_origin: "(%s) "
+     filters:
+       - levels: warn
+         format_pre: "\u001B[33m"    # yellow
+         format_post: "\u001B[39m"
+       - levels: error
+         format_pre: "\u001B[31m"    # red
+         format_post: "\u001B[39m"
+   - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
+     format_time: "\"timestamp\":%ld%03d, "
+     format_level: "\"level\":\"%s\", "
+     format_tag: "\"tag\":\"%s\", "
+     format_origin: "\"origin\":\"%s\", "
+     format_pre_msg: "\"text\":\""
+     format_post: "\"},"
+     flag_json_escape_strings: true
+     filters:
+       - levels: warn
+         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
+       - levels: error
+         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
+#   - file: "{{TMP_DIR}}/maestro.log"
+   # - TTY: "console"
+   #   rotate:
+   #       max_files: 10
+   #       max_file_size: 10000
+   #       max_total_size: 100000
+   #       rotate_on_start: true
+   #   delim: "\n"
+   #   format_time: "[%ld:%d] "
+   #   format_level: "<%s> "
+   #   format_tag: "{%s} "
+   #   format_origin: "(%s) "
+   #   filters:
+   #     - levels: error
+   #       format_pre: "\u001B[31m"
+   #       format_post: "\u001B[39m"
+   #     - levels: debug
+   #       format_pre: "\u001B[36m"
+   #       format_post: "\u001B[39m"
+# JSON file
+   # - file: /tmp/json-maestro.log
+   #   rotate:
+   #       max_files: 10
+   #       max_file_size: 10000
+   #       max_total_size: 100000
+   #       rotate_on_start: true
+   #   delim: "],\n"
+   #   format_time: "{\"time\":\"%ld:%d\"}, "
+   #   format_level: "{\"level\":\"%s\"}, "
+   #   format_tag: "{\"tag\":\"%s\"}, "
+   #   format_origin: "{\"origin\":\"%s\"}, "
+   #   format_pre_msg: "{ \"msg\":\""
+   #   format_post: "\"}"
+   #   flag_json_escape_strings: true
+   #   filters:
+   #     - levels: all
+   #       format_pre: "["     # you will wrap this output with { "log": [ OUTPUT ] }
+
+
+
+#         format_post: "]}"  # I am not sure if this works
+   # - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
+   #   format_time: "\"time\":\"%ld:%d\", "
+   #   format_level: "\"level\":\"%s\", "
+   #   format_tag: "\"tag\":\"%s\", "
+   #   format_origin: "\"origin\":\"%s\", "
+   #   format_pre_msg: "\"msg\":\""
+   #   format_post: "\"}"
+   #   flag_json_escape_strings: true
+   #   filters:
+   #     - levels: all
+   #       format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
+static_file_generators:
+   - name: "devicedb"
+     template_file: "{{SNAP}}/wigwag/wwrelay-utils/conf/maestro-conf/template.devicedb.conf"
+     output_file: "{{SNAP_DATA}}/wigwag/etc/devicejs/devicedb.yaml"
+   - name: "ca_pem"
+     template: "{{ARCH_CA_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/ca.cert.pem"
+   - name: "intermediate_pem"
+     template: "{{ARCH_INTERMEDIATE_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
+   - name: "client_key"
+     template: "{{ARCH_CLIENT_KEY_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/client.key.pem"
+   - name: "client_cert"
+     template: "{{ARCH_CLIENT_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/client.cert.pem"
+   - name: "server_key"
+     template: "{{ARCH_SERVER_KEY_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/server.key.pem"
+   - name: "server_cert"
+     template: "{{ARCH_SERVER_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/server.cert.pem"
+   - name: "ca_chain"
+     template: "{{ARCH_CA_CHAIN_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem"
+   - name: "relayTerm"
+     template_file: "{{SNAP}}/wigwag/wwrelay-utils/conf/maestro-conf/relayTerm.template.json"
+     output_file: "{{SNAP_DATA}}/wigwag/etc/relayterm-config.json"
+config_end: true

--- a/files/maestro/launch-maestro.sh
+++ b/files/maestro/launch-maestro.sh
@@ -14,7 +14,7 @@ if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
 fi
 
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
-    cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
+    cp "$SNAP/config/maestro-config-dell5000.yaml" "$SNAP_DATA/maestro-config.yaml"
 fi
 
 config_file=$SNAP_DATA/maestro-config.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -505,17 +505,17 @@ parts:
         DEBUG= DEBUG2= ./build.sh
         # Install maestro into GOPATH/bin
         go install github.com/armPelionEdge/maestro
-
         # build the grease_echo utility
         cd ${GOPATH}/src/github.com/armPelionEdge/maestro/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/
         make grease_echo
         make standalone_test_logsink
         # Install maestro into the SNAPCRAFT_PART_INSTALL folder so that it is
         # copied into the prime directory during the prime step
-        install ${SNAPCRAFT_PROJECT_DIR}/files/maestro/launch-maestro.sh ${SNAPCRAFT_PART_INSTALL}/
+        install -d ${SNAPCRAFT_PART_INSTALL}/config
         install -d ${SNAPCRAFT_PART_INSTALL}/etc/init.d
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/lib
+        install ${SNAPCRAFT_PROJECT_DIR}/files/maestro/launch-maestro.sh ${SNAPCRAFT_PART_INSTALL}/
         install ${GOPATH}/bin/maestro ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/maestro
         install ${GOPATH}/src/github.com/armPelionEdge/maestro/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/grease_echo ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/grease_echo
         install ${GOPATH}/src/github.com/armPelionEdge/maestro/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/standalone_test_logsink ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/standalone_test_logsink
@@ -524,14 +524,20 @@ parts:
         for f in $ALL_LIBS; do
           install -m 0755 $LIBS_DIR/$f ${SNAPCRAFT_PART_INSTALL}/wigwag/system/lib
         done
+        # fixup the SNAP and SNAP_DATA variables in the config files based on the snap name
+        cp ${SNAPCRAFT_PROJECT_DIR}/files/maestro/config/*.yaml ${SNAPCRAFT_PART_INSTALL}/config/
+        sed -i "s!/snap/pelion-edge!/snap/${SNAPCRAFT_PROJECT_NAME}!" ${SNAPCRAFT_PART_INSTALL}/config/*.yaml
       filesets:
         bin:
           - wigwag/system/bin/*
         lib:
           - wigwag/system/lib/*
+        config:
+          - config/*.yaml
       stage:
         - $lib
         - $bin
+        - $config
         - launch-maestro.sh
     cni:
       plugin: go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,8 +43,6 @@ slots:
           - .
 passthrough:
     layout:
-        /var/lib/pelion-edge:
-            bind: $SNAP_DATA/var/lib/pelion-edge
         /var/lib/dockershim:
             bind: $SNAP_DATA/var/lib/dockershim
         /etc/docker:


### PR DESCRIPTION
With this patchset, changing the name field in the snapcraft.yaml file is sufficient for renaming the snap.
* hard-coded snap name in paths and commands are removed and replaced with snap name environment variables.
* in some cases, the hard-coded name couldn't be removed, such as the docker patches and the maestro-config file, so those files are sed'd during the build step.