### PR TITLE
Fix bug factory reset issue

### DIFF
--- a/files/edge-core/patches/0001-Increasing-Path-Size.patch
+++ b/files/edge-core/patches/0001-Increasing-Path-Size.patch
@@ -1,0 +1,26 @@
+From baf1509fc38903668b2c58398504bc5f036bbc8e Mon Sep 17 00:00:00 2001
+From: "J. Michael Welsh" <mike.welsh@arm.com>
+Date: Tue, 15 Sep 2020 20:47:16 +0000
+Subject: [PATCH] Increasing Path Size
+
+Increasing the path size to fix overflow issues.
+---
+ .../mbed-client-pal/Source/PAL-Impl/Services-API/pal_fileSystem.h       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Services-API/pal_fileSystem.h b/lib/mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Services-API/pal_fileSystem.h
+index ae606eb..11ddb3e 100644
+--- a/lib/mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Services-API/pal_fileSystem.h
++++ b/lib/mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Services-API/pal_fileSystem.h
+@@ -116,7 +116,7 @@
+ 
+ #define PAL_MAX_FILE_NAME_SIZE		8				//!< Max length for file name received by user.
+ #define PAL_MAX_FILE_NAME_SUFFIX	3				//!< Max length for file name suffix.
+-#define PAL_MAX_FOLDER_DEPTH_CHAR	66				//!< Max folder length in chars.
++#define PAL_MAX_FOLDER_DEPTH_CHAR	128				//!< Max folder length in chars.
+ #define PAL_MAX_FILE_AND_FOLDER_LENGTH	(PAL_MAX_FILE_NAME_SIZE + PAL_MAX_FILE_NAME_SUFFIX + PAL_MAX_FOLDER_DEPTH_CHAR + 1) //!< Maximum combined file and folder name length. Plus 1 is for the period that separates file name and file suffix.
+ #define PAL_MAX_FULL_FILE_NAME	(PAL_MAX_FILE_NAME_SUFFIX + PAL_MAX_FOLDER_DEPTH_CHAR + 1) //!< Maximum combined file name. Plus 1 is for the period that separates file name and file suffix.
+ 
+-- 
+2.7.4
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -258,6 +258,7 @@ parts:
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0002-Fixed-edge-cloud-write-errors.patch
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0003-Broadcast-gateway-stats-to-LWM2M-resources.patch
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0004-allow-resources-to-be-named.patch
+        git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-Increasing-Path-Size.patch
         if [ "${COAP_PORT_OVERRIDE_443}" = "true" ]; then
             echo "PATCHING PORT 443 OVERRIDE"
             [ -f config/mbed_cloud_dev_credentials.c ] && sed -i 's,\(coaps://[^:]*:\)5684,\1443,' config/mbed_cloud_dev_credentials.c


### PR DESCRIPTION
Increasing the cache size for filepaths so that we can factory reset
correctly on large snap file names/paths.