### PR TITLE
fix bug: correctly stop kubelet during factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -28,7 +28,7 @@ find /var/log -type f -print0 | xargs -0 truncate --size=0
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
 rm -rf ${SNAP_DATA}/userdata/etc
 rm -rf ${SNAP_DATA}/wigwag/etc/devicejs/devicedb.yaml
-snap stop ${SNAP_INSTANCE_NAME}.kubelet || true
+snapctl stop ${SNAP_INSTANCE_NAME}.kubelet || true
 rm -rf ${SNAP_COMMON}/var/lib/kubelet
 
 # Stop and remove all existing docker containers and images


### PR DESCRIPTION
the 'snap' command is not available from within a snap environment,
but the 'snapctl' command is.