### PR TITLE
fix bug: delete maestro logs on factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -25,8 +25,7 @@ journalctl --vacuum-time=1s
 systemctl stop syslog.socket rsyslog.service
 find /var/log -type f -print0 | xargs -0 truncate --size=0
 
-rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
-rm -rf ${SNAP_DATA}/userdata/etc
+rm -rf ${SNAP_DATA}/userdata
 rm -rf ${SNAP_DATA}/wigwag/etc/devicejs/devicedb.yaml
 snap stop ${SNAP_INSTANCE_NAME}.kubelet || true
 rm -rf ${SNAP_COMMON}/var/lib/kubelet


### PR DESCRIPTION
delete all of userdata folder on factory reset so that the
maestro logs are also deleted.