### PR TITLE
Revert "fix bug: delete maestro logs on factory reset"

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -25,7 +25,8 @@ journalctl --vacuum-time=1s
 systemctl stop syslog.socket rsyslog.service
 find /var/log -type f -print0 | xargs -0 truncate --size=0
 
-rm -rf ${SNAP_DATA}/userdata
+rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
+rm -rf ${SNAP_DATA}/userdata/etc
 rm -rf ${SNAP_DATA}/wigwag/etc/devicejs/devicedb.yaml
 snapctl stop ${SNAP_INSTANCE_NAME}.kubelet || true
 rm -rf ${SNAP_COMMON}/var/lib/kubelet


### PR DESCRIPTION
This reverts commit a2aec4c05431fe7abcfc4cb9cfbe0082f5876216.

This deletes too much data: it deletes userdata/mbed/mcc_config
which contains cloud credentials and this may be a bad thing
if we're in factory mode.