### PR TITLE
change devicedb syncSessionPeriod to 1 minute

### DIFF
--- a/files/maestro/template.devicedb.conf
+++ b/files/maestro/template.devicedb.conf
@@ -19,7 +19,7 @@ syncSessionLimit: 2
 # result in slow convergence rates for replicas that have not been in contact
 # for some time. A rate on the order of seconds is reccomended generally
 # **REQUIRED**
-syncSessionPeriod: 1000
+syncSessionPeriod: 60000
 
 # This field adjusts the maximum number of objects that can be transferred in
 # one sync session. A higher number will result in faster convergence between


### PR DESCRIPTION
Increase the Sync Period in DeviceDB for the Gateway Side.  This causes the Gateway to initiate fewer syncs, reducing the network usage.