### PR TITLE
Fix output format for platform-version

### DIFF
--- a/files/platform-version/platform-version.sh
+++ b/files/platform-version/platform-version.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps -X GET | jq -r '[.result[]|{id,revision}]|sort_by(.id,.revision)' | md5sum
+curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps -X GET | jq -r '[.result[]|{id,revision}]|sort_by(.id,.revision)' | md5sum | cut -f 1 -d " "


### PR DESCRIPTION
Remove the trailing "-" (indicating stdin) from the output of
md5sum

Signed-off-by: Kyle Stein <kyle.stein@arm.com>