### PR TITLE
Change grade to devel for FOTA testing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ version: "1.18.1"
 summary: Pelion Edge
 description: Pelion Edge
 confinement: strict
-grade: stable
+grade: devel
 architectures:
   - amd64
 plugs:


### PR DESCRIPTION
In order to prevent accidental publishing on the stable/candidate
release tracks, the grade must be devel.  Devel grade can only be
publised to edge/beta tracks which is where we are allowed to
test FOTA functionality.

The grade should be changed back to stable during the release build
process.