### PR TITLE
Platform version available from relay-term

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -213,6 +213,8 @@ parts:
     platform-version:
       plugin: dump
       source: files/platform-version/
+      organize:
+        platform-version.sh: bin/platform-version.sh
     identity:
       plugin: dump
       source: files/identity/


### PR DESCRIPTION
platform-version.sh now installed in the $SNAP/bin directory so
it is accessible in the default path in relay-term

Signed-off-by: Kyle Stein <kyle.stein@arm.com>