### PR TITLE
Maestro DeviceDB Networking

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -386,7 +386,7 @@ parts:
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git
-      source-commit: ab9ae5817e579741e33accb8237d74b86ee316de
+      source-commit: 80fb3c7e1644501e685d20be304cdb1c7600c414
       build-packages:
         - python
         - build-essential
@@ -401,7 +401,7 @@ parts:
         cd go/src/github.com/armPelionEdge
         git clone https://github.com/armPelionEdge/maestro.git
         cd maestro
-        git checkout ab9ae5817e579741e33accb8237d74b86ee316de
+        git checkout 80fb3c7e1644501e685d20be304cdb1c7600c414
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_BUILD}/go
         # Specify GOBIN so that maestro/build.sh doesn't do unexpected things


### PR DESCRIPTION
Adding the Maestro branch to make DeviceDB networking work with
snap-pelion-edge.